### PR TITLE
24 changes to readme for clarity and more setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,205 @@
-# 15926-4-RDL-CITS3200
+<h1 align="center">
+  <br>
+  ISO15926vis
+  <br>
+</h1>
+<h4 align="center">Web interface to visualise the ISO 15926 Reference Data Library.</h4>
+<p align="center">
+  <a href="#introduction">Introduction</a> •
+  <a href="#getting-started">Getting started</a> •
+  <a href="#development">Development</a> •
+  <a href="#deployment">Deployment</a> •
+  <a href="#credits">Credits</a>
+</p>
 
-## Visualisation of the ISO 15926-4 Reference Data Library
+## Introduction
 
-## Overview
-This project aims to develop an interactive visualisation for an equipment reference data library as described in the ISO 15926-4 Standard. The goal is to create a web-based interface that allows users to interrogate the data and visualise the hierarchical relations.
+ISO15926vis is an interactive graph visualisation for the equipment Reference Data Library (RDL) described in the [ISO 15926-4 Standard](https://15926.org/).
 
-## Purpose
-The current browser, https://data.15926.org/rdl/, is frustrating to use due to the lack of hierarchical visualisation. This project aims to enhance the user experience and improve data accessibility.
+This project assists in navigating the hierarchical relationships of classes defined by the RDL, supplementing data on the [current RDL browser](https://data.15926.org/rdl/) on which the hierarchy can be difficult to interpret.
 
+🚧 This project is currently in the early stages of development and many things are subject to change. 🚧
 
-## Setup (Development)
-This project uses a mix of pre-commit checks and github actions in the workflow, ensuring clean code. To properly setup the project follow these steps.
+## Getting started
 
-### Clone the repositry
-  `git clone https://github.com/nlp-tlp/15926-4-RDL-CITS3200.git`
+These instructions will install dependencies get a copy of the project up and running on your local machine. This is also needed for testing and deployment. For self-hosting see the [deployment section](#deployment).
 
-### Install dependencies
-`sudo apt-get update`
+### Installing dependencies
 
-`sudo apt-get upgrade` (OPTIONAL)
+Dependencies must first be installed before running the client / server / CLI.
 
-`sudo apt install python3-venv`
+#### Git clone
 
-`./setup.sh` (Do not run with `sudo`)
+Git clone the repository:
 
-### Build and run Docker containers
-`cd src`
+```
+git clone https://github.com/nlp-tlp/15926-4-RDL-CITS3200.git
+```
 
-`docker compose up --build`
+#### Setup script
 
-- Any changes to main files (dependencies, settings, etc.) require the containers to be rebuilt.
+A script is available to automatically run all the steps listed below for client and server dependencies.
 
-**NOTE: IF USING WSL, THE DOCKER DESKTOP APP MUST BE INSTALLED AND CONFIGURED (https://docs.docker.com/desktop/wsl/)**
+⚠️ The script was built primarily for Linux systems and your system may not be compatible. If it fails (doesn't output "Setup complete") or your OS is incompatible with these instructions, you can install dependencies manually following the sections below. ⚠️
 
-### Run Tests
+The script requires Python Venv to run. If not already installed, run:
+
+```
+sudo apt install python3-venv
+```
+
+In the root directory, run:
+
+```
+./setup.sh
+```
+
+If you encounter the error `-bash: ./setup.sh: /bin/bash^M: bad interpreter: No such file or directory` and you are using WSL:
+
+Run `sed -i 's/\r$//' setup.sh`, then run the script again.
+
+#### Client dependency installation
+
+If you intend to run the client, download [NVM](https://github.com/nvm-sh/nvm) from the official source or using a package manager for your OS.
+
+Then, use NVM to install [NPM](https://nodejs.org/en/download/package-manager):
+
+```
+nvm install 20
+nvm use 20
+```
+
+Install NPM dependencies in the main directory for [Husky Git hooks](https://typicode.github.io/husky/) and initialise Husky:
+
+```
+npm i
+npx husky-init
+cp .husky/pre-commit.example .husky/pre-commit
+```
+
+Install NPM dependencies for the client from the main directory with:
+
+```
+npm i --prefix src/client
+```
+
+#### Server / CLI dependency installation
+
+It is recommended that you install the server / CLI Python packages in a virtual environment. Any will do, but the following are instructions for activating venv:
+
+```
+python3 -m venv src/server/venv
+source src/server/venv/bin/activate
+```
+
+If you intend to run the server / CLI, install the dependencies from requirements.txt:
+
+```
+pip install -r src/server/requirements.txt
+```
+
+### Running the project
+
+This project consists of a Vue client, Flask server, and command-line interface. The following instructions will run them locally.
+
+#### Client
+
+To access the Vue web interface, run from the root directory:
+
+```
+cd src/client
+npm run dev
+```
 
 #### Server
-`cd src/server`
 
-`source ./venv/bin/activate`
+To run the Flask server, run from the root directory:
 
-`pytest`
+```
+cd src/server
+flask run
+```
+
+#### CLI
+
+🚧 CLI setup is currently under development. 🚧
+
+## Development
+
+The following sections include instructions for testing and adding dependencies, for use by developers.
+
+### Testing
+
+Testing frameworks have been set up for project functionality.
+
+#### Server tests
+
+Tests for the Flask server are written with Pytest. If you are already using a different virtual environment system, skip `source ./venv/bin/activate` below:
+
+```
+cd src/server
+source ./venv/bin/activate
+pytest
+```
+
+#### Client tests
+
+🚧 Client test framework setup is currently under development. 🚧
+
+#### CLI tests
+
+🚧 CLI test framework setup is currently under development. 🚧
+
+### Adding dependencies
+
+Follow these steps if you need to add a package during development
+
+#### Adding to client
+
+Packages are added through NPM in the client directory.
+
+For any dependencies that should be there in the production environment, run:
+
+```
+npm i <package_name> --save
+```
+
+For any dependencies needed for development but not prod (e.g. type checking with ESLint), run:
+
+```
+npm i <package_name> --save-dev
+```
+
+#### Adding to server
+
+Packages should be added through `pip` in your virtual environment:
+
+```
+pip install <package_name>
+pip freeze > requirements.txt
+```
+
+###
+
+## Deployment
+
+### Docker
+
+You can host the client and server locally with Docker. This requires the Docker CLI to be installed with docker compose.
+
+Note that changes to main files (dependencies, settings, etc.) require the containers to be rebuilt.
+
+From the root directory, run:
+
+```
+cd src
+docker compose up --build
+```
+
+⚠️ If using WSL, the docker desktop app must be [installed and configured for WSL](https://docs.docker.com/desktop/wsl/). ⚠️
+
+## Credits
+
+This project is being developed by students of the University of Western Australia (UWA) as part of the unit CITS3200 (Professional Computing), as Team 14 of the 2024 Semester 2 cohort.
+
+Our team members include: Cameron O’Neill, Heidi Leow, Paul Maingi, Ryan Dorman, Shuai Shao, and Vinita Rathore.

--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@
 
 ISO15926vis is an interactive graph visualisation for the equipment Reference Data Library (RDL) described in the [ISO 15926-4 Standard](https://15926.org/).
 
-This project assists in navigating the hierarchical relationships of classes defined by the RDL, supplementing data on the [current RDL browser](https://data.15926.org/rdl/) on which the hierarchy can be difficult to interpret.
+This project assists in navigating the hierarchical relationships of classes defined by the RDL, accessible through the [current RDL browser](https://data.15926.org/rdl/) on which the hierarchy can be difficult to interpret.
 
 🚧 This project is currently in the early stages of development and many things are subject to change. 🚧
 
 ## Getting started
 
-These instructions will install dependencies get a copy of the project up and running on your local machine. This is also needed for testing and deployment. For self-hosting see the [deployment section](#deployment).
+These instructions will [install dependencies](#installing-dependencies) get a copy of the project [up and running](#running-the-project) on your local machine. This is also needed for testing and deployment.
 
 ### Installing dependencies
 
-Dependencies must first be installed before running the client / server / CLI.
+This project consists of a Vue client, Flask server, and command-line interface. Dependencies must first be installed before running any of these.
 
 #### Git clone
 
@@ -54,9 +54,7 @@ In the root directory, run:
 ./setup.sh
 ```
 
-If you encounter the error `-bash: ./setup.sh: /bin/bash^M: bad interpreter: No such file or directory` and you are using WSL:
-
-Run `sed -i 's/\r$//' setup.sh`, then run the script again.
+If you encounter the error `-bash: ./setup.sh: /bin/bash^M: bad interpreter: No such file or directory` and you are using WSL, run `sed -i 's/\r$//' setup.sh` then rerun the script.
 
 #### Client dependency installation
 
@@ -100,7 +98,7 @@ pip install -r src/server/requirements.txt
 
 ### Running the project
 
-This project consists of a Vue client, Flask server, and command-line interface. The following instructions will run them locally.
+The following instructions can be used to run the Vue client, Flask server, and command-line interface locally.
 
 #### Client
 
@@ -134,21 +132,20 @@ Testing frameworks have been set up for project functionality.
 
 #### Server tests
 
-Tests for the Flask server are written with Pytest. If you are already using a different virtual environment system, skip `source ./venv/bin/activate` below:
+Tests for the Flask server are written with Pytest. It is recommended that you activate your virtual environment first (e.g. venv), then run in the root directory:
 
 ```
 cd src/server
-source ./venv/bin/activate
 pytest
 ```
 
 #### Client tests
 
-🚧 Client test framework setup is currently under development. 🚧
+🚧 Client testing setup is currently under development. 🚧
 
 #### CLI tests
 
-🚧 CLI test framework setup is currently under development. 🚧
+🚧 CLI testing setup is currently under development. 🚧
 
 ### Adding dependencies
 
@@ -170,7 +167,7 @@ For any dependencies needed for development but not prod (e.g. type checking wit
 npm i <package_name> --save-dev
 ```
 
-#### Adding to server
+#### Adding to server / CLI
 
 Packages should be added through `pip` in your virtual environment:
 
@@ -178,8 +175,6 @@ Packages should be added through `pip` in your virtual environment:
 pip install <package_name>
 pip freeze > requirements.txt
 ```
-
-###
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ git clone https://github.com/nlp-tlp/15926-4-RDL-CITS3200.git
 
 A script is available to automatically run all the steps listed below for client and server dependencies.
 
-⚠️ The script was built primarily for Linux systems and your system may not be compatible. If it fails (doesn't output "Setup complete") or your OS is incompatible with these instructions, you can install dependencies manually following the sections below. ⚠️
+⚠️ The script was built for Linux systems and your system may not be compatible. If you cannot follow these instructions on your OS, you can install dependencies manually following the sections below. ⚠️
 
-The script requires Python Venv to run. If not already installed, run:
+The script requires Python Venv to run. If not already installed, run (on Linux):
 
 ```
+sudo apt update
 sudo apt install python3-venv
 ```
 
@@ -111,7 +112,7 @@ npm run dev
 
 #### Server
 
-To run the Flask server, run from the root directory:
+To run the Flask server, activate your virtual environment and run from the root directory:
 
 ```
 cd src/server


### PR DESCRIPTION
### Description
### Description
Update the README for more detailed instructions on running the server / client and also how to add new dependencies. 
* `flask run`, `npm run dev` for running 
* adding new dependencies to either:
  * client: must `cd` into `/src/client` then run `npm install` (with either `--save` or `--save-dev`)  `--save` is for production so things like d3, and other main dependencies used for the site should use `--save`. `--save-dev` is for development (so things like eslint, type checking, and other things that ONLY RUN IN DEVELOPMENT). It might break if not done correctly. (without either tag it doesnt properly add it to the package file so one does need to be used)
  * server: `cd` into `/src/server` then run `source ./venv/bin/activate` then do `pip install (package)` to install it to the env and not the local machine.

### To-do
* [x] Update instructions for running
* [x] Update instructions for adding dependencies

### Notes
Restructured the README for clarity, added some nicer indications for important info to note, and also a little html to make it look nicer / for better navigation.

### Linked issues
Closes #24 