### PR TITLE
48 some minor js docs and styling fixes

### DIFF
--- a/src/client/src/assets/main.css
+++ b/src/client/src/assets/main.css
@@ -6,6 +6,7 @@ body {
   padding: 0;
   height: 100%;
   width: 100%;
+  overflow: hidden;
 }
 
 #app {

--- a/src/client/src/assets/main.css
+++ b/src/client/src/assets/main.css
@@ -1,8 +1,20 @@
 @import './base.css';
 
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100%;
+}
+
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
+  position: relative;
+  top: 2.5rem;
+  left: 1rem;
+  width: 100%;
+  height: 100%;
+  margin: 0;
   padding: 2rem;
   font-weight: normal;
 }

--- a/src/client/src/components/GraphInfoSidepane.vue
+++ b/src/client/src/components/GraphInfoSidepane.vue
@@ -65,7 +65,7 @@ export default {
   width: 50px;
   position: fixed;
   z-index: 1;
-  top: 70px;
+  top: 4.5rem;
   right: 0;
   background-color: white;
   overflow-x: hidden;

--- a/src/client/src/components/GraphInfoSidepane.vue
+++ b/src/client/src/components/GraphInfoSidepane.vue
@@ -40,23 +40,23 @@ export default {
 
 <template>
   <div :class="['right-sidepanel', { 'sidepanel-expanded': isRightExpanded }]">
-    <div class="right-header">
-      <p class="right-text">Right Sidepanel</p>
-      <button class="right-btn" @click="toggleRightNav">&#9776;</button>
-    </div>
+    <button class="right-btn" @click="toggleRightNav">&#9776;</button>
+    <p class="right-text">Right Sidepanel</p>
   </div>
 </template>
 
 <style scoped>
 .right-sidepanel {
+  display: flex;
+  align-items: flex-start;
+  padding-top: 0.25rem;
   height: 100%;
   width: 50px;
   position: fixed;
   z-index: 1;
-  top: 4.5rem;
+  top: var(--navbar-height, 4.5rem);
   right: 0;
-  background-color: white;
-  overflow-x: hidden;
+  background-color: transparent;
   transition:
     width 0.5s ease,
     background-color 0.5s ease;
@@ -67,29 +67,11 @@ export default {
   background-color: var(--color-nav-background);
 }
 
-.right-header {
-  width: 100%;
-  height: 60px;
-  background-color: white;
-  color: var(--color-nav-background);
-  padding: 10px;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  z-index: 2;
-  transition:
-    width 0.5s ease,
-    background-color 0.5s ease;
-}
-
-.sidepanel-expanded .right-header {
-  background-color: var(--color-nav-background);
-  color: white;
-}
-
 .right-btn {
-  margin-right: 10px;
-  background-color: white;
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background-color: transparent;
   color: var(--color-nav-background);
   transition:
     background-color 0.5s ease,
@@ -106,15 +88,14 @@ export default {
 }
 
 .right-text {
-  margin-left: 10px;
+  margin: 0.75rem 0 0 1rem;
+  color: white;
   transition:
     opacity 0.5s ease,
     transform 0.5s ease;
   opacity: 0;
   visibility: hidden;
   white-space: nowrap;
-  font-size: 16px;
-  cursor: default;
 }
 
 .sidepanel-expanded .right-text {

--- a/src/client/src/components/GraphInfoSidepane.vue
+++ b/src/client/src/components/GraphInfoSidepane.vue
@@ -1,52 +1,40 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 
-const isRightExpanded = ref(false)
+// Define props with default values using withDefaults (type-based declaration)
+const props = withDefaults(
+  defineProps<{
+    /**
+     * Determines if the side panel is initially expanded (default: false).
+     */
+    initialExpanded?: boolean
+  }>(),
+  {
+    initialExpanded: false
+  }
+)
 
-function toggleRightNav() {
+// Initialise isRightExpanded with the value of initialExpanded prop
+const isRightExpanded = ref(props.initialExpanded)
+
+function toggleRightNav(): void {
   isRightExpanded.value = !isRightExpanded.value
 }
 </script>
 
 <script lang="ts">
 /**
- * GraphInfoSidepane component represents the right side panel in the graph view.
+ * GraphInfoSidepane component represents the expandable side panel containing information functionality.
  *
- * This component provides an expandable side panel on the right side of the graph view.
- * The panel can be toggled open or closed by clicking the associated button.
- *
- * @function toggleRightNav
- * Toggles the right side panel between expanded and collapsed states.
- *
- * This method inverts the value of `isRightExpanded`. When the button associated
- * with the side panel is clicked, `toggleRightNav` is called, changing the panel's
- * state from open to closed or from closed to open.
- *
- * @prop {boolean} isRightExpanded - Indicates whether the right side panel is expanded.
- * This prop controls the expansion state of the side panel.
+ * @param {boolean} initialExpanded - Determines if the side panel is initially expanded (default: false).
  *
  * @example
- * // Example usage within the template
- * <button @click="toggleRightNav">Toggle Right Panel</button>
- *
- * <div :class="{ 'right-sidepanel-expanded': isRightExpanded }">
- *   <!-- Content of the side panel -->
- * </div>
+ * <GraphInfoSidepane :initialExpanded="true" />
+ * <GraphInfoSidepane initialExpanded />
+ * <GraphInfoSidepane />
  */
 export default {
-  name: 'GraphInfoSidepane',
-  props: {
-    isRightExpanded: {
-      type: Boolean,
-      default: false
-    }
-  },
-  emits: ['update:isRightExpanded'],
-  methods: {
-    toggleRightNav() {
-      this.$emit('update:isRightExpanded', !this.isRightExpanded)
-    }
-  }
+  name: 'GraphInfoSidepane'
 }
 </script>
 

--- a/src/client/src/components/GraphSearchSidepane.vue
+++ b/src/client/src/components/GraphSearchSidepane.vue
@@ -1,56 +1,40 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 
-const isLeftExpanded = ref(false)
+// Define props with default values using withDefaults (type-based declaration)
+const props = withDefaults(
+  defineProps<{
+    /**
+     * Determines if the side panel is initially expanded (default: false).
+     */
+    initialExpanded?: boolean
+  }>(),
+  {
+    initialExpanded: false
+  }
+)
 
-function toggleLeftNav() {
+// Initialise isLeftExpanded with the value of initialExpanded prop
+const isLeftExpanded = ref(props.initialExpanded)
+
+function toggleLeftNav(): void {
   isLeftExpanded.value = !isLeftExpanded.value
 }
 </script>
 
 <script lang="ts">
 /**
- * GraphSearchSidepane component represents the left side panel in the graph view.
+ * GraphSearchSidepane component represents the expandable side panel containing search functionality.
  *
- * This component provides an expandable side panel on the left side of the graph view.
- * The panel can be toggled open or closed by clicking the associated button.
- *
- * @function toggleLeftNav
- * Toggles the left side panel between expanded and collapsed states.
- *
- * This method inverts the value of `isLeftExpanded`. When the button associated
- * with the side panel is clicked, `toggleLeftNav` is called, changing the panel's
- * state from open to closed or from closed to open.
- *
- * @prop {boolean} isLeftExpanded - Indicates whether the left side panel is expanded.
- * This prop controls the expansion state of the side panel.
+ * @param {boolean} initialExpanded - Determines if the side panel is initially expanded (default: false).
  *
  * @example
- * // Example usage within the template
- * <button @click="toggleLeftNav">Toggle Left Panel</button>
- *
- * <div :class="{ 'left-sidepanel-expanded': isLeftExpanded }">
- *   <!-- Content of the side panel -->
- * </div>
+ * <GraphSearchSidepane :initialExpanded="true" />
+ * <GraphSearchSidepane initialExpanded />
+ * <GraphSearchSidepane />
  */
 export default {
-  name: 'GraphSearchSidepane',
-  props: {
-    isLeftExpanded: {
-      type: Boolean,
-      default: false
-    }
-  },
-  emits: ['update:isLeftExpanded'],
-  methods: {
-    /**
-     * Toggles the left side panel between expanded and collapsed states.
-     * Emits an event to update the `isLeftExpanded` prop.
-     */
-    toggleLeftNav() {
-      this.$emit('update:isLeftExpanded', !this.isLeftExpanded)
-    }
-  }
+  name: 'GraphSearchSidepane'
 }
 </script>
 

--- a/src/client/src/components/GraphSearchSidepane.vue
+++ b/src/client/src/components/GraphSearchSidepane.vue
@@ -40,23 +40,23 @@ export default {
 
 <template>
   <div :class="['left-sidepanel', { 'sidepanel-expanded': isLeftExpanded }]">
-    <div class="left-header">
-      <button class="left-btn" @click="toggleLeftNav">&#9776;</button>
-      <p class="left-text">Left Sidepanel</p>
-    </div>
+    <button class="left-btn" @click="toggleLeftNav">&#9776;</button>
+    <p class="left-text">Left Sidepanel</p>
   </div>
 </template>
 
 <style scoped>
 .left-sidepanel {
+  display: flex;
+  align-items: flex-start;
+  padding-top: 0.25rem;
   height: 100%;
   width: 50px;
   position: fixed;
   z-index: 1;
-  top: 4.5rem;
+  top: var(--navbar-height, 4.5rem);
   left: 0;
-  background-color: white;
-  overflow-x: hidden;
+  background-color: transparent;
   transition:
     width 0.5s ease,
     background-color 0.5s ease;
@@ -67,29 +67,11 @@ export default {
   background-color: var(--color-nav-background);
 }
 
-.left-header {
-  width: 100%;
-  height: 60px;
-  background-color: white;
-  color: var(--color-nav-background);
-  padding: 10px;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  z-index: 2;
-  transition:
-    width 0.5s ease,
-    background-color 0.5s ease;
-}
-
-.sidepanel-expanded .left-header {
-  background-color: var(--color-nav-background);
-  color: white;
-}
-
 .left-btn {
-  margin-left: 10px;
-  background-color: white;
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  background-color: transparent;
   color: var(--color-nav-background);
   transition:
     background-color 0.5s ease,
@@ -106,15 +88,14 @@ export default {
 }
 
 .left-text {
-  margin-right: 10px;
+  margin: 0.75rem 1rem 0 auto;
+  color: white;
   transition:
     opacity 0.5s ease,
     transform 0.5s ease;
   opacity: 0;
   visibility: hidden;
   white-space: nowrap;
-  font-size: 16px;
-  cursor: default;
 }
 
 .sidepanel-expanded .left-text {

--- a/src/client/src/components/GraphSearchSidepane.vue
+++ b/src/client/src/components/GraphSearchSidepane.vue
@@ -69,7 +69,7 @@ export default {
   width: 50px;
   position: fixed;
   z-index: 1;
-  top: 70px;
+  top: 4.5rem;
   left: 0;
   background-color: white;
   overflow-x: hidden;

--- a/src/client/src/components/NavBar.vue
+++ b/src/client/src/components/NavBar.vue
@@ -41,6 +41,7 @@ export default {
 <style scoped>
 .navbar {
   width: 100%;
+  height: 4.5rem;
   font-size: 1.1rem;
   /* Ensures NavBar items are on NavBar */
   display: flex;

--- a/src/client/src/components/NavBar.vue
+++ b/src/client/src/components/NavBar.vue
@@ -9,7 +9,7 @@ import NavBarItem from './NavBarItem.vue'
  * NavBar component represents the navigation bar for the application.
  *
  * This component includes the title of the application and a set of navigation items.
- * Each navigation item is represented by the NavBarItem component.
+ * Each navigation item is represented by the {@link NavBarItem} component.
  *
  * @example
  * <NavBar />

--- a/src/client/src/components/NavBarItem.vue
+++ b/src/client/src/components/NavBarItem.vue
@@ -9,7 +9,7 @@ import { RouterLink } from 'vue-router'
  * @param {string} to - The route path for the navigation item.
  * @param {string} label - The label text displayed for the navigation item.
  *
- * @slot icon - (OPTIONAL) The icon to display for the navigation item.
+ * @slot `icon` - Optional slot for an icon to display with the navigation item.
  *
  * @example
  * <NavBarItem to="/home" label="Home">
@@ -21,10 +21,16 @@ import { RouterLink } from 'vue-router'
 export default {
   name: 'NavBarItem',
   props: {
+    /**
+     * The route path for the navigation item.
+     */
     to: {
       type: String,
       required: true
     },
+    /**
+     * The label text displayed for the navigation item.
+     */
     label: {
       type: String,
       required: true

--- a/src/client/src/components/NavBarItem.vue
+++ b/src/client/src/components/NavBarItem.vue
@@ -3,10 +3,16 @@ import { computed } from 'vue'
 import { RouterLink } from 'vue-router'
 
 const props = defineProps({
+  /**
+   * The route path or URL for the navigation item.
+   */
   to: {
     type: String,
     required: true
   },
+  /**
+   * The label text displayed for the navigation item.
+   */
   label: {
     type: String,
     required: true

--- a/src/client/src/components/icons/IconDocumentation.vue
+++ b/src/client/src/components/icons/IconDocumentation.vue
@@ -1,3 +1,15 @@
+<script lang="ts">
+/**
+ * IconDocumentation component represents an SVG icon for documentation.
+ *
+ * @example
+ * <IconDocumentation />
+ */
+export default {
+  name: 'IconDocumentation'
+}
+</script>
+
 <template>
   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="20" fill="currentColor">
     <path

--- a/src/client/src/components/icons/IconGraph.vue
+++ b/src/client/src/components/icons/IconGraph.vue
@@ -1,3 +1,15 @@
+<script lang="ts">
+/**
+ * IconGraph component represents an SVG icon for a graph.
+ *
+ * @example
+ * <IconGraph />
+ */
+export default {
+  name: 'IconGraph'
+}
+</script>
+
 <template>
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/src/client/src/views/GraphView.vue
+++ b/src/client/src/views/GraphView.vue
@@ -4,9 +4,11 @@ import GraphSearchSidepane from '../components/GraphSearchSidepane.vue'
 </script>
 
 <template>
-  <h2>Graph</h2>
-  <GraphSearchSidepane />
-  <GraphInfoSidepane />
+  <div>
+    <h1>Graph</h1>
+    <GraphSearchSidepane />
+    <GraphInfoSidepane />
+  </div>
 </template>
 
 <style scoped></style>

--- a/src/client/src/views/GraphView.vue
+++ b/src/client/src/views/GraphView.vue
@@ -4,7 +4,7 @@ import GraphSearchSidepane from '../components/GraphSearchSidepane.vue'
 </script>
 
 <template>
-  <div>
+  <div class="container">
     <h1>Graph</h1>
     <GraphSearchSidepane />
     <GraphInfoSidepane />


### PR DESCRIPTION
### Description
Fix some minor issues in the JSDocs and add some for the icon components. Fix some minor styling issues related to the app container and the side-pane/navbar components.

- [x] JSDocs for Icon components
- [x] Fix navbar and side-panes detaching from each other in smaller displays
![image](https://github.com/user-attachments/assets/35978e92-500d-4bf9-86b0-c1f5ad6e118e)

- [x] Fix side-pane component props
- [x] Fix main app container width restrictions
![image](https://github.com/user-attachments/assets/0e212c61-f961-4366-ae9f-ab5c641429a8)


### Notes
In the Graph view, the display width will have to be adjusted (made reactive) to take into account expanded/collapsed side-panes.

### Linked issues
Closes #48 