### PR TITLE
27 read info by id api endpoint

### DIFF
--- a/src/server/app/controllers.py
+++ b/src/server/app/controllers.py
@@ -46,6 +46,10 @@ def get_all_node_info(uri, graph):
         "properties": {},  # Handle anything else
     }
 
+    # Ensure node exists within the database
+    if not check_uri_exists(uri=uri, graph=graph):
+        raise ValueError(f"URI '{uri}' does not exist within the database")
+
     uri_ref = URIRef(uri)
 
     # Query for all triples where the node is the subject

--- a/src/server/app/controllers.py
+++ b/src/server/app/controllers.py
@@ -62,6 +62,29 @@ def get_basic_node_info(uri, graph):
 
 # Get all information (predicates and objects) for a given node in the RDFLib graph.
 def get_all_node_info(uri, graph, all_info=True):
+    """
+    Retrieves all available information about a given node in the RDFLib graph. This includes
+    specific properties such as label, types, deprecation date, definition, and parent nodes
+    (subClassOf). If 'all_info' is set to True, additional properties are also returned.
+
+    Args:
+        uri (str): The URI of the node to retrieve information for.
+        graph (rdflib.Graph): The RDFLib graph to query the node's information from.
+        all_info (bool): A flag indicating whether to retrieve additional properties (default: True).
+
+    Returns:
+        dict: A dictionary containing all available information about the node, including:
+            - id (str): The URI of the node.
+            - label (str, optional): The rdfs:label value of the node.
+            - types (list of str): A list of rdf:type values (if the node has multiple types).
+            - dep (str, optional): The meta:valDeprecationDate value (deprecation date).
+            - definition (str, optional): The skos:definition of the node.
+            - parents (list of str): A list of URIs for parent nodes (rdfs:subClassOf).
+            - properties (dict): A dictionary of other predicates and their corresponding objects (only included if 'all_info' is True).
+
+    Raises:
+        ValueError: If the provided URI does not exist within the RDFLib graph.
+    """
     # Initialise dictionary based on option to include all extra properties.
     if all_info:
         node_info = {

--- a/src/server/app/controllers.py
+++ b/src/server/app/controllers.py
@@ -61,16 +61,28 @@ def get_basic_node_info(uri, graph):
 
 
 # Get all information (predicates and objects) for a given node in the RDFLib graph.
-def get_all_node_info(uri, graph):
-    node_info = {
-        "id": str(uri),
-        "label": None,  # Handle rdfs:label
-        "types": [],  # Handle multiple rdf:type entries
-        "dep": None,  # Handle meta/valDeprecationDate
-        "definition": None,  # Handle skos:definition
-        "parents": [],  # Handle rdfs:subClassOf
-        "properties": {},  # Handle anything else
-    }
+def get_all_node_info(uri, graph, all_info=True):
+    # Initialise dictionary based on option to include all extra properties.
+    if all_info:
+        node_info = {
+            "id": str(uri),
+            "label": None,  # Handle rdfs:label
+            "types": [],  # Handle multiple rdf:type entries
+            "dep": None,  # Handle meta/valDeprecationDate
+            "definition": None,  # Handle skos:definition
+            "parents": [],  # Handle rdfs:subClassOf
+            "properties": {},  # Handle anything else
+        }
+
+    else:
+        node_info = {
+            "id": str(uri),
+            "label": None,  # Handle rdfs:label
+            "types": [],  # Handle multiple rdf:type entries
+            "dep": None,  # Handle meta/valDeprecationDate
+            "definition": None,  # Handle skos:definition
+            "parents": [],  # Handle rdfs:subClassOf
+        }
 
     # Ensure node exists within the database
     if not check_uri_exists(uri=uri, graph=graph):
@@ -101,15 +113,16 @@ def get_all_node_info(uri, graph):
             node_info["parents"].append(str(obj))
 
         else:
-            # Add the predicate and object to the 'properties' dictionary
-            pred_str = str(predicate)
-            obj_str = str(obj)
+            if all_info:
+                # Add the predicate and object to the 'properties' dictionary
+                pred_str = str(predicate)
+                obj_str = str(obj)
 
-            # Store multiple values under the same predicate
-            if pred_str in node_info["properties"]:
-                node_info["properties"][pred_str].append(obj_str)
-            else:
-                node_info["properties"][pred_str] = [obj_str]
+                # Store multiple values under the same predicate
+                if pred_str in node_info["properties"]:
+                    node_info["properties"][pred_str].append(obj_str)
+                else:
+                    node_info["properties"][pred_str] = [obj_str]
 
     return node_info
 

--- a/src/server/app/controllers.py
+++ b/src/server/app/controllers.py
@@ -1,8 +1,9 @@
 from .config import Config
-from rdflib import URIRef, RDFS, Literal, Namespace
+from rdflib import URIRef, Literal, RDF, RDFS, Namespace
 
-# Define the namespace for deprecation date
+# Define the namespace for meta and SKOS
 META = Namespace("http://data.15926.org/meta/")
+SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
 
 
 def get_root_node():
@@ -29,6 +30,56 @@ def get_basic_node_info(uri, graph):
     for _, _, deprecation_date in graph.triples((uri, META.valDeprecationDate, None)):
         if isinstance(deprecation_date, Literal):
             node_info["dep"] = str(deprecation_date)
+
+    return node_info
+
+
+# Get all information (predicates and objects) for a given node in the RDFLib graph.
+def get_all_node_info(uri, graph):
+    node_info = {
+        "id": str(uri),
+        "label": None,  # Handle rdfs:label
+        "types": [],  # Handle multiple rdf:type entries
+        "dep": None,  # Handle meta/valDeprecationDate
+        "definition": None,  # Handle skos:definition
+        "parents": [],  # Handle rdfs:subClassOf
+        "properties": {},  # Handle anything else
+    }
+
+    uri_ref = URIRef(uri)
+
+    # Query for all triples where the node is the subject
+    for predicate, obj in graph.predicate_objects(subject=uri_ref):
+        # If the predicate is rdfs:label, store it separately
+        if predicate == RDFS.label and isinstance(obj, Literal):
+            node_info["label"] = str(obj)
+
+        # If the predicate is rdf:type, store it in the 'types' list
+        elif predicate == RDF.type:
+            node_info["types"].append(str(obj))
+
+        # If the predicate is the deprecation date, store it separately
+        elif predicate == META.valDeprecationDate and isinstance(obj, Literal):
+            node_info["dep"] = str(obj)
+
+        # If the predicate is skos:definition, store it separately
+        elif predicate == SKOS.definition and isinstance(obj, Literal):
+            node_info["definition"] = str(obj)
+
+        # If the predicate is rdfs:subClassOf, store it in the 'parents' list
+        elif predicate == RDFS.subClassOf:
+            node_info["parents"].append(str(obj))
+
+        else:
+            # Add the predicate and object to the 'properties' dictionary
+            pred_str = str(predicate)
+            obj_str = str(obj)
+
+            # Store multiple values under the same predicate
+            if pred_str in node_info["properties"]:
+                node_info["properties"][pred_str].append(obj_str)
+            else:
+                node_info["properties"][pred_str] = [obj_str]
 
     return node_info
 

--- a/src/server/app/routes.py
+++ b/src/server/app/routes.py
@@ -48,7 +48,7 @@ def root():
         return jsonify({"error": "No ROOT found"}), 404
 
 
-@main.route("/graph/children/<path:node_uri>", methods=["GET"])
+@main.route("/node/children/<path:node_uri>", methods=["GET"])
 def children(node_uri):
     """
     Fetches the children of a given node in the graph.
@@ -98,8 +98,8 @@ def children(node_uri):
     return jsonify({"id": node_uri, "children": children})
 
 
-@main.route("/graph/children/", methods=["GET"])
-@main.route("/graph/children", methods=["GET"])
+@main.route("/node/children/", methods=["GET"])
+@main.route("/node/children", methods=["GET"])
 def invalid_children():
     """
     Fallback route for invalid children requests.
@@ -108,7 +108,7 @@ def invalid_children():
         JSON: Error message indicating the ID/URI was not provided.
     """
     return (
-        jsonify({"error": "ID/URI not provided. Must use '/graph/children/<id>'"}),
+        jsonify({"error": "ID/URI not provided. Must use '/node/children/<id>'"}),
         400,
     )
 

--- a/src/server/app/routes.py
+++ b/src/server/app/routes.py
@@ -71,4 +71,27 @@ def get_children():
         return jsonify({"error": "ID/URI not provided"}), 400
 
 
-# @main.route("/graph/local-hierarchy/")
+@main.route("/node/info", methods=["GET"])
+def info():
+    # Extract the custom ID from the query parameters
+    node_uri = request.args.get("id")
+
+    if node_uri:
+        try:
+            # Check if the graph is available
+            if not hasattr(current_app, "graph"):
+                raise AttributeError("Graph is not initialised")
+
+            info = controllers.get_all_node_info(uri=node_uri, graph=current_app.graph)
+
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 404
+        except AttributeError as e:
+            return jsonify({"error": str(e)}), 500
+        except Exception as e:
+            return jsonify({"error": "Internal Error"}), 500
+
+        return jsonify(info)
+
+    else:
+        return jsonify({"error": "ID/URI not provided"}), 400

--- a/src/server/tests/conftest.py
+++ b/src/server/tests/conftest.py
@@ -1,11 +1,12 @@
 import pytest
 from app import create_app
 from app.config import TestConfig
-from rdflib import Graph, Namespace, Literal, URIRef, RDFS
+from rdflib import Graph, Namespace, Literal, URIRef, RDF, RDFS
 
 
 # Define the namespace for your test data
 META = Namespace("http://data.15926.org/meta/")
+SKOS = Namespace("http://www.w3.org/2004/02/skos/core#")
 
 
 @pytest.fixture(scope="module")
@@ -20,18 +21,35 @@ def sample_graph():
     root_node = URIRef("http://data.15926.org/dm/Thing")
     child1 = URIRef("http://data.15926.org/dm/Child1")
     child2 = URIRef("http://data.15926.org/dm/Child2")
+    child3 = URIRef("http://data.15926.org/dm/Child3")
 
-    # Add triples to the graph
+    # Add labels
     graph.add((root_node, RDFS.label, Literal("Thing")))
     graph.add((child1, RDFS.label, Literal("Child One")))
     graph.add((child2, RDFS.label, Literal("Child Two")))
+    graph.add((child3, RDFS.label, Literal("Child Three")))
 
     # Add subclass relationships (children)
     graph.add((child1, RDFS.subClassOf, root_node))
     graph.add((child2, RDFS.subClassOf, root_node))
+    graph.add((child3, RDFS.subClassOf, child1))  # Make child3 a subclass of child1
 
     # Add deprecation date for one of the children
     graph.add((child1, META.valDeprecationDate, Literal("2021-03-21Z")))
+
+    # Add types to the nodes
+    graph.add((root_node, RDF.type, URIRef("http://data.15926.org/dm/RootType")))
+    graph.add((child1, RDF.type, URIRef("http://data.15926.org/dm/ChildType")))
+    graph.add((child1, RDF.type, URIRef("http://data.15926.org/dm/AnotherType")))
+
+    # Add a skos:definition to one of the nodes
+    graph.add((child1, SKOS.definition, Literal("Child One is a sample node.")))
+    graph.add((child2, SKOS.definition, Literal("Child Two definition.")))
+
+    # Add custom properties
+    graph.add(
+        (root_node, URIRef("http://example.org/hasProperty"), Literal("Some property"))
+    )
 
     return graph
 

--- a/src/server/tests/functional/test_database.py
+++ b/src/server/tests/functional/test_database.py
@@ -197,7 +197,7 @@ def test_get_node_info(test_client):
     assert len(json_data["properties"]) == 0  # No custom properties added to Child1
 
 
-def test_get_all_root_node_info_with_properties(test_client):
+def test_get_root_node_info_with_properties(test_client):
     """
     Test that the root node information retrieved via the '/node/info' endpoint includes label, types,
     properties, and no deprecation date.
@@ -224,3 +224,35 @@ def test_get_all_root_node_info_with_properties(test_client):
 
     # Ensure no definition was added for the root node
     assert json_data["definition"] is None
+
+
+def test_get_root_node_info_without_properties(test_client):
+    """
+    Test that the root node information retrieved via the '/node/info' endpoint includes only the label,
+    types, deprecation date, parents, and definition, but no additional properties, when 'all_info=false'.
+    """
+    # Node URI for the root node
+    node_uri = "http://data.15926.org/dm/Thing"
+
+    # Send a request to the '/node/info' endpoint with the root node URI and 'all_info=false'
+    response = test_client.get(f"/node/info/{node_uri}?all_info=false")
+    json_data = response.get_json()
+
+    # Assert the basic fields are correct
+    assert response.status_code == 200
+    assert json_data["id"] == node_uri
+    assert json_data["label"] == "Thing"
+    assert json_data["dep"] is None  # Root node does not have a deprecation date
+
+    # Check that the types include the correct type
+    assert "http://data.15926.org/dm/RootType" in json_data["types"]
+
+    # Ensure no custom properties exist, since 'all_info' is False
+    assert "properties" not in json_data  # 'properties' field should not be present
+
+    # Ensure no definition was added for the root node
+    assert json_data["definition"] is None
+
+    # Check parents field to ensure it's handled correctly (empty or filled based on data)
+    assert "parents" in json_data
+    assert len(json_data["parents"]) == 0 or isinstance(json_data["parents"], list)

--- a/src/server/tests/functional/test_database.py
+++ b/src/server/tests/functional/test_database.py
@@ -167,7 +167,7 @@ def test_get_children_with_extra_parents(test_client):
     assert "extra_parents" not in child1_info
 
 
-def test_get_all_node_info(test_client):
+def test_get_node_info(test_client):
     """
     Test that the node information retrieved via the '/node/info' endpoint includes label, types,
     deprecation date, definition, and properties.
@@ -176,7 +176,7 @@ def test_get_all_node_info(test_client):
     node_uri = "http://data.15926.org/dm/Child1"
 
     # Send a request to the '/node/info' endpoint with the node URI
-    response = test_client.get(f"/node/info?id={node_uri}")
+    response = test_client.get(f"/node/info/{node_uri}")
     json_data = response.get_json()
 
     # Assert the basic fields are correct
@@ -197,7 +197,7 @@ def test_get_all_node_info(test_client):
     assert len(json_data["properties"]) == 0  # No custom properties added to Child1
 
 
-def test_get_root_node_info_with_properties(test_client):
+def test_get_all_root_node_info_with_properties(test_client):
     """
     Test that the root node information retrieved via the '/node/info' endpoint includes label, types,
     properties, and no deprecation date.
@@ -206,7 +206,7 @@ def test_get_root_node_info_with_properties(test_client):
     node_uri = "http://data.15926.org/dm/Thing"
 
     # Send a request to the '/node/info' endpoint with the root node URI
-    response = test_client.get(f"/node/info?id={node_uri}")
+    response = test_client.get(f"/node/info/{node_uri}?all_info=true")
     json_data = response.get_json()
 
     # Assert the basic fields are correct

--- a/src/server/tests/functional/test_database.py
+++ b/src/server/tests/functional/test_database.py
@@ -1,10 +1,10 @@
 def test_get_children_with_default_deprecation(test_client):
     """
-    Test the '/graph/children' route to fetch the children of the root node.
+    Test the '/node/children' route to fetch the children of the root node.
     With dep=False by default, it should exclude Child1 (which has a deprecation date).
     """
-    # Send a request to the /graph/children route with the root node's URI (default dep=False)
-    response = test_client.get("/graph/children/http://data.15926.org/dm/Thing")
+    # Send a request to the /node/children route with the root node's URI (default dep=False)
+    response = test_client.get("/node/children/http://data.15926.org/dm/Thing")
 
     # Parse the JSON response
     data = response.get_json()
@@ -20,12 +20,12 @@ def test_get_children_with_default_deprecation(test_client):
 
 def test_get_children_without_deprecation(test_client):
     """
-    Test the '/graph/children' route to fetch the children of the root node.
+    Test the '/node/children' route to fetch the children of the root node.
     With dep=False, it should exclude Child1 (which has a deprecation date).
     """
-    # Send a request to the /graph/children route with the root node's URI (default dep=False)
+    # Send a request to the /node/children route with the root node's URI (default dep=False)
     response = test_client.get(
-        "/graph/children/http://data.15926.org/dm/Thing?dep=false"
+        "/node/children/http://data.15926.org/dm/Thing?dep=false"
     )
 
     # Parse the JSON response
@@ -42,13 +42,11 @@ def test_get_children_without_deprecation(test_client):
 
 def test_get_children_with_deprecation(test_client):
     """
-    Test the '/graph/children' route to fetch the children of the root node with dep=True.
+    Test the '/node/children' route to fetch the children of the root node with dep=True.
     Both Child1 (with a deprecation date) and Child2 should be included.
     """
-    # Send a request to the /graph/children route with the root node's URI and dep=True
-    response = test_client.get(
-        "/graph/children/http://data.15926.org/dm/Thing?dep=true"
-    )
+    # Send a request to the /node/children route with the root node's URI and dep=True
+    response = test_client.get("/node/children/http://data.15926.org/dm/Thing?dep=true")
 
     # Parse the JSON response
     data = response.get_json()
@@ -103,10 +101,10 @@ def test_get_root_node_info(test_client):
 
 def test_invalid_query_to_children(test_client):
     """
-    Test an invalid query to '/graph/children', where the provided URI doesn't exist.
+    Test an invalid query to '/node/children', where the provided URI doesn't exist.
     """
     invalid_uri = "http://data.15926.org/dm/NonExistent"
-    response = test_client.get(f"/graph/children/{invalid_uri}")
+    response = test_client.get(f"/node/children/{invalid_uri}")
 
     # Parse the JSON response
     data = response.get_json()
@@ -119,12 +117,12 @@ def test_invalid_query_to_children(test_client):
 
 def test_get_children_with_extra_parents(test_client):
     """
-    Test the '/graph/children' route to fetch the children of the root node.
+    Test the '/node/children' route to fetch the children of the root node.
     Ensure that the 'extra_parents' field is included for nodes with multiple parents.
     """
-    # Send a request to the /graph/children route with the root node's URI
+    # Send a request to the /node/children route with the root node's URI
     response = test_client.get(
-        "/graph/children/http://data.15926.org/dm/Thing?dep=true&ex_parents=true"
+        "/node/children/http://data.15926.org/dm/Thing?dep=true&ex_parents=true"
     )
 
     # Parse the JSON response

--- a/src/server/tests/functional/test_routes.py
+++ b/src/server/tests/functional/test_routes.py
@@ -52,3 +52,51 @@ def test_graph_children_route_missing_id(test_client):
     assert response.status_code == 400
     assert "error" in json_data
     assert json_data["error"] == "ID/URI not provided"
+
+
+def test_node_info_route(test_client):
+    """
+    Test the '/node/info' route with a valid ID.
+    """
+    node_uri = "http://data.15926.org/dm/Thing"
+    response = test_client.get(f"/node/info?id={node_uri}")
+    json_data = response.get_json()
+
+    # Assert the response is valid and contains the correct node information
+    assert response.status_code == 200
+    assert json_data["id"] == node_uri
+    assert "label" in json_data
+    assert "types" in json_data
+    assert "dep" in json_data
+    assert "definition" in json_data
+    assert "properties" in json_data
+
+
+def test_node_info_route_missing_id(test_client):
+    """
+    Test the '/node/info' route without providing an ID in the query parameters.
+    """
+    response = test_client.get("/node/info")
+    json_data = response.get_json()
+
+    # Assert the response is a 400 Bad Request due to missing ID/URI
+    assert response.status_code == 400
+    assert "error" in json_data
+    assert json_data["error"] == "ID/URI not provided"
+
+
+def test_node_info_route_invalid_id(test_client):
+    """
+    Test the '/node/info' route with an invalid node ID.
+    """
+    invalid_node_uri = "http://data.15926.org/dm/NonExistentNode"
+    response = test_client.get(f"/node/info?id={invalid_node_uri}")
+    json_data = response.get_json()
+
+    # Assert the response is a 404 Not Found due to the invalid node ID
+    assert response.status_code == 404
+    assert "error" in json_data
+    assert (
+        json_data["error"]
+        == f"URI '{invalid_node_uri}' does not exist within the database"
+    )

--- a/src/server/tests/functional/test_routes.py
+++ b/src/server/tests/functional/test_routes.py
@@ -59,7 +59,7 @@ def test_node_info_route(test_client):
     Test the '/node/info' route with a valid ID.
     """
     node_uri = "http://data.15926.org/dm/Thing"
-    response = test_client.get(f"/node/info?id={node_uri}")
+    response = test_client.get(f"/node/info/{node_uri}")
     json_data = response.get_json()
 
     # Assert the response is valid and contains the correct node information
@@ -76,13 +76,13 @@ def test_node_info_route_missing_id(test_client):
     """
     Test the '/node/info' route without providing an ID in the query parameters.
     """
-    response = test_client.get("/node/info")
+    response = test_client.get("/node/info/")
     json_data = response.get_json()
 
     # Assert the response is a 400 Bad Request due to missing ID/URI
     assert response.status_code == 400
     assert "error" in json_data
-    assert json_data["error"] == "ID/URI not provided"
+    assert json_data["error"] == "ID/URI not provided. Must use '/node/info/<id>'"
 
 
 def test_node_info_route_invalid_id(test_client):
@@ -90,7 +90,7 @@ def test_node_info_route_invalid_id(test_client):
     Test the '/node/info' route with an invalid node ID.
     """
     invalid_node_uri = "http://data.15926.org/dm/NonExistentNode"
-    response = test_client.get(f"/node/info?id={invalid_node_uri}")
+    response = test_client.get(f"/node/info/{invalid_node_uri}")
     json_data = response.get_json()
 
     # Assert the response is a 404 Not Found due to the invalid node ID

--- a/src/server/tests/functional/test_routes.py
+++ b/src/server/tests/functional/test_routes.py
@@ -28,10 +28,10 @@ def test_graph_root_route(test_client):
 
 def test_graph_children_route(test_client):
     """
-    Test the '/graph/children' route with a valid ID.
+    Test the '/node/children' route with a valid ID.
     """
     node_uri = "http://data.15926.org/dm/Thing"
-    response = test_client.get(f"/graph/children/{node_uri}")
+    response = test_client.get(f"/node/children/{node_uri}")
     json_data = response.get_json()
 
     # Assert correct response for children of the root node
@@ -43,15 +43,15 @@ def test_graph_children_route(test_client):
 
 def test_graph_children_route_missing_id(test_client):
     """
-    Test the '/graph/children' route without providing an ID in the query parameters.
+    Test the '/node/children' route without providing an ID in the query parameters.
     """
-    response = test_client.get("/graph/children/")
+    response = test_client.get("/node/children/")
     json_data = response.get_json()
 
     # Assert the response is a 400 Bad Request due to missing ID/URI
     assert response.status_code == 400
     assert "error" in json_data
-    assert json_data["error"] == "ID/URI not provided. Must use '/graph/children/<id>'"
+    assert json_data["error"] == "ID/URI not provided. Must use '/node/children/<id>'"
 
 
 def test_node_info_route(test_client):

--- a/src/server/tests/unit/test_controllers.py
+++ b/src/server/tests/unit/test_controllers.py
@@ -4,6 +4,7 @@ from app.controllers import (
     get_children,
     check_uri_exists,
     str_to_bool,
+    get_all_node_info,
 )
 
 
@@ -65,6 +66,26 @@ def test_get_children_with_deprecation_included(sample_graph):
             ), "Child1 should have a deprecation date."
         else:
             assert child["dep"] is None, "Child2 should not have a deprecation date."
+
+
+def test_get_all_node_info(sample_graph):
+    """
+    Test the get_all_node_info function from controllers.py.
+    """
+    # Test with Child1
+    node_uri = "http://data.15926.org/dm/Child1"
+    node_info = get_all_node_info(node_uri, sample_graph)
+
+    # Assert the basic fields are correct
+    assert node_info["id"] == node_uri
+    assert node_info["label"] == "Child One"
+    assert node_info["dep"] == "2021-03-21Z"  # Child1 has a deprecation date
+    assert "http://data.15926.org/dm/ChildType" in node_info["types"]
+    assert node_info["definition"] == "Child One is a sample node."
+
+    # Ensure there are no extra properties for Child1
+    assert "properties" in node_info
+    assert len(node_info["properties"]) == 0  # No custom properties
 
 
 def test_check_uri_exists(sample_graph):

--- a/src/server/tests/unit/test_controllers.py
+++ b/src/server/tests/unit/test_controllers.py
@@ -98,7 +98,7 @@ def test_get_children_with_extra_parents(sample_graph):
 
 def test_get_all_node_info(sample_graph):
     """
-    Test the get_all_node_info function from controllers.py.
+    Test the get_all_node_info function with default all_node parameter from controllers.py.
     """
     # Test with Child1
     node_uri = "http://data.15926.org/dm/Child1"


### PR DESCRIPTION
## Description
Following #55's closure, the information route (`/node/info/<id>`) has been completed with adequate testing included. By default all possible information is returned in a JSON dict, however unknown properties can be ignored with parameter `all_info=false` added to the query.

Some examples:
![image](https://github.com/user-attachments/assets/b8d72783-ade5-4fc5-9d08-79d0120089e7)

![image](https://github.com/user-attachments/assets/a0ecc941-27d5-4887-9fc3-4fd1df2c3217)

## To-do list Completed
- [x] Get a single class' metadata from our database
- [x] Serve data through read-info-by-id endpoint

## Misc
Closes #27