### PR TITLE
75 has_children bug fix

### DIFF
--- a/src/server/app/controllers.py
+++ b/src/server/app/controllers.py
@@ -180,7 +180,7 @@ def has_children(uri: str, graph, dep: bool) -> bool:
     Args:
         uri (str): The URI of the node to check for children.
         graph (rdflib.Graph): The RDFLib graph to query.
-        dep (bool, optional): Whether to include deprecated nodes. Default is False.
+        dep (bool): Whether to include deprecated nodes.
 
     Returns:
         bool: True if the node has children, otherwise False.
@@ -189,12 +189,13 @@ def has_children(uri: str, graph, dep: bool) -> bool:
 
     # Query the graph for triples where the given URI is the object of rdfs:subClassOf (i.e., if any triples are found, the node has children)
     for child, _, _ in graph.triples((None, RDFS.subClassOf, uri_ref)):
-        # Check dep flag to see whether to include deprecated nodes in children count
+        # Check deprecation flag
         if dep:
             return True
         else:
-            # If the child is not deprecated, return True
-            if not get_basic_node_info(child, graph).get("dep"):
+            # Directly query for the deprecation date of the child node
+            deprecated = any(graph.triples((child, META.valDeprecationDate, None)))
+            if not deprecated:
                 return True
 
     return False

--- a/src/server/app/controllers.py
+++ b/src/server/app/controllers.py
@@ -173,21 +173,31 @@ def get_root_node_info(graph) -> dict[str, any]:
     return get_basic_node_info(root_node_ref, graph)
 
 
-def has_children(uri: str, graph) -> bool:
+def has_children(uri: str, graph, dep: bool) -> bool:
     """
-    Checks if a given node has any children.
+    Checks if a given node has any children, considering the deprecation status.
 
     Args:
         uri (str): The URI of the node to check for children.
         graph (rdflib.Graph): The RDFLib graph to query.
+        dep (bool, optional): Whether to include deprecated nodes. Default is False.
 
     Returns:
         bool: True if the node has children, otherwise False.
     """
     uri_ref = URIRef(uri)  # Convert the URI string to an RDFLib URIRef object
 
-    # Query the graph for triples where the given URI is the object of rdfs:subClassOf (i.e., has children)
-    return any(graph.triples((None, RDFS.subClassOf, uri_ref)))
+    # Query the graph for triples where the given URI is the object of rdfs:subClassOf (i.e., if any triples are found, the node has children)
+    for child, _, _ in graph.triples((None, RDFS.subClassOf, uri_ref)):
+        # Check dep flag to see whether to include deprecated nodes in children count
+        if dep:
+            return True
+        else:
+            # If the child is not deprecated, return True
+            if not get_basic_node_info(child, graph).get("dep"):
+                return True
+
+    return False
 
 
 def get_children(
@@ -254,7 +264,7 @@ def get_children(
 
             # Add the 'has_children' field
             if children_flag:
-                child_info["has_children"] = has_children(str(child), graph)
+                child_info["has_children"] = has_children(str(child), graph, dep)
 
             # Append the child info to the children list
             children_list.append(child_info)

--- a/src/server/tests/conftest.py
+++ b/src/server/tests/conftest.py
@@ -23,24 +23,35 @@ def sample_graph():
     child2 = URIRef("http://data.15926.org/dm/Child2")
     extra_parent = URIRef("http://data.15926.org/dm/ExtraParent")
     child3 = URIRef("http://data.15926.org/dm/Child3")
+    child4 = URIRef("http://data.15926.org/dm/Child4")
+    child5 = URIRef("http://data.15926.org/dm/Child5")
 
     # Add labels
     graph.add((root_node, RDFS.label, Literal("Thing")))
     graph.add((child1, RDFS.label, Literal("Child One")))
     graph.add((child2, RDFS.label, Literal("Child Two")))
     graph.add((child3, RDFS.label, Literal("Child Three")))
+    graph.add((child4, RDFS.label, Literal("Child Four")))
+    graph.add((child5, RDFS.label, Literal("Child Five")))
     graph.add((extra_parent, RDFS.label, Literal("Another Parent")))
 
     # Add subclass relationships (children)
     graph.add((child1, RDFS.subClassOf, root_node))
     graph.add((child2, RDFS.subClassOf, root_node))
+    graph.add((child4, RDFS.subClassOf, root_node))
 
     # Add subclass relationship for another parent
     graph.add((child2, RDFS.subClassOf, extra_parent))
     graph.add((child3, RDFS.subClassOf, child1))  # Make child3 a subclass of child1
+    graph.add((child5, RDFS.subClassOf, child4))  # Make child5 a subclass of child4
 
-    # Add deprecation date for one of the children
-    graph.add((child1, META.valDeprecationDate, Literal("2021-03-21Z")))
+    # Add deprecation dates
+    graph.add(
+        (child1, META.valDeprecationDate, Literal("2021-03-21Z"))
+    )  # Child1 is deprecated
+    graph.add(
+        (child5, META.valDeprecationDate, Literal("2021-03-21Z"))
+    )  # Child5 is deprecated
 
     # Add types to the nodes
     graph.add((root_node, RDF.type, URIRef("http://data.15926.org/dm/RootType")))

--- a/src/server/tests/unit/test_controllers.py
+++ b/src/server/tests/unit/test_controllers.py
@@ -1,3 +1,4 @@
+import pytest
 from rdflib import URIRef
 from app.controllers import (
     get_root_node_info,
@@ -32,19 +33,44 @@ def test_get_root_node_info(sample_graph):
     assert root_info["dep"] is None, "Root node should not have a deprecation date."
 
 
-def test_has_children(sample_graph):
+def test_has_children_without_deprecation(sample_graph):
     """
-    Test the has_children function from controllers.py.
+    Test has_children with dep=False (default) to exclude deprecated nodes.
     """
-    # Test with a node that has children
+    # Test a non-deprecated node with non-deprecated children
     assert has_children(
-        "http://data.15926.org/dm/Thing", sample_graph
-    ), "Root node should have children."
+        "http://data.15926.org/dm/Thing", sample_graph, dep=False
+    ), "Root node should have children when dep=False."
 
-    # Test with a node that doesn't have children
+    # Test a non-deprecated node with no children
     assert not has_children(
-        "http://data.15926.org/dm/Child2", sample_graph
-    ), "Child2 should not have children."
+        "http://data.15926.org/dm/Child2", sample_graph, dep=False
+    ), "Child2 should not have children when dep=False."
+
+    # Test a non-deprecated node with deprecated children
+    assert not has_children(
+        "http://data.15926.org/dm/Child4", sample_graph, dep=False
+    ), "Child4 should not have children when dep=False, Child5 is deprecated."
+
+
+def test_has_children_with_deprecation_included(sample_graph):
+    """
+    Test has_children with dep=True to include deprecated nodes.
+    """
+    # Test a non-deprecated node with deprecated and non-deprecated children
+    assert has_children(
+        "http://data.15926.org/dm/Thing", sample_graph, dep=True
+    ), "Root node should have children when dep=True."
+
+    # Test a non-deprecated node with no children
+    assert not has_children(
+        "http://data.15926.org/dm/Child2", sample_graph, dep=True
+    ), "Child2 should not have children when dep=True."
+
+    # Test a non-deprecated node with deprecated children
+    assert has_children(
+        "http://data.15926.org/dm/Child4", sample_graph, dep=True
+    ), "Child4 should have children when dep=True, Child5 is deprecated."
 
 
 def test_get_children_without_deprecation(sample_graph):
@@ -54,10 +80,17 @@ def test_get_children_without_deprecation(sample_graph):
     # Get children of the root node with default dep=False
     children = get_children("http://data.15926.org/dm/Thing", sample_graph, dep=False)
 
-    # Validate that only Child2 is returned (Child1 has a deprecation date)
-    assert len(children) == 1, "Only Child2 should be returned when dep=False."
+    # Sort children by id to ensure consistent order
+    children.sort(key=lambda x: x["id"])
+
+    # Validate that only Child2 and Child4 are returned, Child1 is deprecated
+    assert (
+        len(children) == 2
+    ), "Root node should have 2 children when dep=False, Child2 and Child4."
     assert children[0]["id"] == "http://data.15926.org/dm/Child2"
     assert children[0]["dep"] is None, "Child2 should not have a deprecation date."
+    assert children[1]["id"] == "http://data.15926.org/dm/Child4"
+    assert children[1]["dep"] is None, "Child4 should not have a deprecation date."
 
 
 def test_get_children_with_deprecation_included(sample_graph):
@@ -68,12 +101,15 @@ def test_get_children_with_deprecation_included(sample_graph):
     children = get_children("http://data.15926.org/dm/Thing", sample_graph, dep=True)
 
     # Validate that both children are returned
-    assert len(children) == 2, "Root node should have 2 children when dep=True."
+    assert (
+        len(children) == 3
+    ), "Root node should have 3 children when dep=True, Child1, Child2, and Child4."
 
     # Check child IDs and deprecation dates
     child_ids = {child["id"] for child in children}
     assert "http://data.15926.org/dm/Child1" in child_ids
     assert "http://data.15926.org/dm/Child2" in child_ids
+    assert "http://data.15926.org/dm/Child4" in child_ids
 
     for child in children:
         if child["id"] == "http://data.15926.org/dm/Child1":
@@ -81,7 +117,9 @@ def test_get_children_with_deprecation_included(sample_graph):
                 child["dep"] == "2021-03-21Z"
             ), "Child1 should have a deprecation date."
         else:
-            assert child["dep"] is None, "Child2 should not have a deprecation date."
+            assert (
+                child["dep"] is None
+            ), "Child2 and Child4 should not have deprecation dates."
 
 
 def test_get_children_with_extra_parents(sample_graph):
@@ -132,6 +170,34 @@ def test_get_all_node_info(sample_graph):
     assert len(node_info["properties"]) == 0  # No custom properties
 
 
+def test_get_all_node_info_non_existent_node(sample_graph):
+    """
+    Test the get_all_node_info function with a non-existent node to ensure it raises a ValueError.
+    """
+    non_existent_node_uri = "http://data.15926.org/dm/NonExistentNode"
+    with pytest.raises(
+        ValueError,
+        match=f"URI '{non_existent_node_uri}' does not exist within the database",
+    ):
+        get_all_node_info(non_existent_node_uri, sample_graph)
+
+
+def test_get_all_node_info_multiple_types(sample_graph):
+    """
+    Test the get_all_node_info function with a node that has multiple types.
+    """
+    node_uri = "http://data.15926.org/dm/Child1"
+    node_info = get_all_node_info(node_uri, sample_graph)
+
+    # Assert the basic fields are correct
+    assert node_info["id"] == node_uri
+    assert node_info["label"] == "Child One"
+    assert node_info["dep"] == "2021-03-21Z"  # Child1 has a deprecation date
+    assert "http://data.15926.org/dm/ChildType" in node_info["types"]
+    assert "http://data.15926.org/dm/AnotherType" in node_info["types"]
+    assert node_info["definition"] == "Child One is a sample node."
+
+
 def test_check_uri_exists(sample_graph):
     """
     Test the check_uri_exists function from controllers.py.
@@ -147,35 +213,41 @@ def test_check_uri_exists(sample_graph):
     ), "Non-existent URI should not exist."
 
 
-def test_str_to_bool():
+@pytest.mark.parametrize(
+    "input_value, expected_result",
+    [
+        # Test truthy string values
+        ("true", True),
+        ("1", True),
+        ("t", True),
+        ("y", True),
+        ("yes", True),
+        ("True", True),  # Test case insensitivity
+        ("YES", True),  # Test case insensitivity
+        # Test falsy string values
+        ("false", False),
+        ("0", False),
+        ("f", False),
+        ("n", False),
+        ("no", False),
+        ("False", False),  # Test case insensitivity
+        ("NO", False),  # Test case insensitivity
+        # Test non-string values
+        (True, True),  # Boolean True remains True
+        (False, False),  # Boolean False remains False
+        (1, True),  # Integer 1 is considered True
+        (0, False),  # Integer 0 is considered False
+        (None, False),  # None is considered False
+        # Test invalid values
+        ("invalid", False),  # Any non-truthy string should be False
+        ("", False),  # Empty string should be False
+        (" ", False),  # Whitespace string should be False
+        ("null", False),
+        ("None", False),
+    ],
+)
+def test_str_to_bool(input_value, expected_result):
     """
-    Test the str_to_bool function with various inputs to verify correct behavior.
+    Parameterized test for the str_to_bool function with various inputs to verify correct behavior.
     """
-
-    # Test truthy string values
-    assert str_to_bool("true") is True
-    assert str_to_bool("1") is True
-    assert str_to_bool("t") is True
-    assert str_to_bool("y") is True
-    assert str_to_bool("yes") is True
-    assert str_to_bool("True") is True  # Test case insensitivity
-    assert str_to_bool("YES") is True  # Test case insensitivity
-
-    # Test falsy string values
-    assert str_to_bool("false") is False
-    assert str_to_bool("0") is False
-    assert str_to_bool("f") is False
-    assert str_to_bool("n") is False
-    assert str_to_bool("no") is False
-    assert str_to_bool("False") is False  # Test case insensitivity
-    assert str_to_bool("NO") is False  # Test case insensitivity
-
-    # Test non-string values
-    assert str_to_bool(True) is True  # Boolean True remains True
-    assert str_to_bool(False) is False  # Boolean False remains False
-    assert str_to_bool(1) is True  # Integer 1 is considered True
-    assert str_to_bool(0) is False  # Integer 0 is considered False
-    assert str_to_bool(None) is False  # None is considered False
-
-    # Test invalid values
-    assert str_to_bool("invalid") is False  # Any non-truthy string should be False
+    assert str_to_bool(input_value) == expected_result


### PR DESCRIPTION
### Description
Fixes the `has_children` bug where the deprecation status is not considered when checking whether a node has children.

### To-do Completed
- [x] Ensure the function takes into consideration the deprecation status when checking if a node has any children

with deprecation=false
![image](https://github.com/user-attachments/assets/73692985-2f25-45e5-88f1-6eaff0639052)
![image](https://github.com/user-attachments/assets/449f9566-3f5c-40cf-8a8a-0354309b625c)

with deprecation=true
![image](https://github.com/user-attachments/assets/68d50393-d24e-493b-9f11-00d4f2c589d9)
![image](https://github.com/user-attachments/assets/b801a3f4-9797-454f-afb2-845b58e3628f)


### Linked Issues

Closes #75 