### PR TITLE
64 search api endpoint

### DIFF
--- a/src/server/app/config.py
+++ b/src/server/app/config.py
@@ -8,13 +8,15 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 # Shared configuration
 class Config:
     ROOT_NODE_URI = "http://data.15926.org/dm/Thing"  # Root node of graph
-    DB_HISTORY_FILE = os.path.join(basedir, "../../db/history.json")
-    DB_STORAGE_DIR = os.path.join(basedir, "../../db/storage")
-    SECRET_KEY = os.environ.get("FLASK_SECRET_KEY", "default-key-for-testing")
-    # Set local secret key with
-    # BASH: echo 'export FLASK_SECRET_KEY="your_secret_key_here"' >> ~/.bashrc && source ~/.bashrc
-    # WINDOWS CMD: set FLASK_SECRET_KEY=your_secret_key_here
-    # with dotenv, you can instead create a .env file and set a local secret key in the same style as Windows
+    DB_HISTORY_FILE = os.path.join(
+        basedir, "../../db/history.json"
+    )  # Storage location of the database HISTORY file (SHOULD BE RELATIVE)
+    DB_STORAGE_DIR = os.path.join(
+        basedir, "../../db/storage"
+    )  # Storage location of the database files (SHOULD BE RELATIVE)
+    MAX_SEARCH_LIMIT = (
+        25  # Maximum possible number of items returned by the search api end points
+    )
 
 
 class DeploymentConfig(Config):

--- a/src/server/app/config.py
+++ b/src/server/app/config.py
@@ -7,16 +7,17 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 # Shared configuration
 class Config:
-    ROOT_NODE_URI = "http://data.15926.org/dm/Thing"  # Root node of graph
-    DB_HISTORY_FILE = os.path.join(
-        basedir, "../../db/history.json"
-    )  # Storage location of the database HISTORY file (SHOULD BE RELATIVE)
-    DB_STORAGE_DIR = os.path.join(
-        basedir, "../../db/storage"
-    )  # Storage location of the database files (SHOULD BE RELATIVE)
-    MAX_SEARCH_LIMIT = (
-        25  # Maximum possible number of items returned by the search api end points
-    )
+    # Root node of graph
+    ROOT_NODE_URI = "http://data.15926.org/dm/Thing"
+
+    # Storage location of the database HISTORY file (SHOULD BE RELATIVE)
+    DB_HISTORY_FILE = os.path.join(basedir, "../../db/history.json")
+
+    # Storage location of the database files (SHOULD BE RELATIVE)
+    DB_STORAGE_DIR = os.path.join(basedir, "../../db/storage")
+
+    # Maximum possible number of items returned by the search api end points
+    MAX_SEARCH_LIMIT = 25
 
 
 class DeploymentConfig(Config):

--- a/src/server/app/controllers.py
+++ b/src/server/app/controllers.py
@@ -256,7 +256,7 @@ def search(search_key, field, graph, dep=False, limit=5):
     unique_subjects = set()  # Set to track unique subjects
     count = 0
 
-    # Check if the field is "LABEL", otherwise default to "URI"
+    # Check if the field is "LABEL"
     if field.upper() == "LABEL":
         # Search by label (rdfs:label) for partial match
         for subject, predicate, obj in graph.triples((None, RDFS.label, None)):
@@ -277,6 +277,8 @@ def search(search_key, field, graph, dep=False, limit=5):
 
                 if count >= limit:
                     break
+
+    # Otherwise default to "URI"
     else:
         # Default or explicit "URI" search (substring match)
         for subject in graph.subjects():

--- a/src/server/app/controllers.py
+++ b/src/server/app/controllers.py
@@ -254,13 +254,14 @@ def search(search_key, field, graph, dep=False, limit=5):
 
     results = []
     unique_subjects = set()  # Set to track unique subjects
+    search_key_lower = search_key.lower()
     count = 0
 
     # Check if the field is "LABEL"
     if field.upper() == "LABEL":
         # Search by label (rdfs:label) for partial match
         for subject, predicate, obj in graph.triples((None, RDFS.label, None)):
-            if isinstance(obj, Literal) and search_key.lower() in str(obj).lower():
+            if isinstance(obj, Literal) and search_key_lower in str(obj).lower():
                 if subject in unique_subjects:
                     continue  # Skip if subject is already added
 
@@ -282,7 +283,7 @@ def search(search_key, field, graph, dep=False, limit=5):
     else:
         # Default or explicit "URI" search (substring match)
         for subject in graph.subjects():
-            if search_key.lower() in str(subject).lower():
+            if search_key_lower in str(subject).lower():
                 if subject in unique_subjects:
                     continue  # Skip if subject is already added
 

--- a/src/server/app/models.py
+++ b/src/server/app/models.py
@@ -1,6 +1,6 @@
 import json
 
-from .config import Config
+from app.config import Config
 
 
 # Load the latest database (Turtle file) into the RDFLib graph based on the history file.

--- a/src/server/app/routes.py
+++ b/src/server/app/routes.py
@@ -191,7 +191,9 @@ def search_by_id(node_uri):
     include_deprecation = controllers.str_to_bool(
         request.args.get("dep", default=False)
     )
-    limit = min(int(request.args.get("limit", 5)), int(Config.MAX_SEARCH_LIMIT))
+    # Ensure limit is not negative and within max limits
+    abs_limit = abs(int(request.args.get("limit", 5)))
+    limit = min(abs_limit, int(Config.MAX_SEARCH_LIMIT))
 
     try:
         # Check if the graph is available
@@ -233,7 +235,9 @@ def search_by_label(node_label):
     include_deprecation = controllers.str_to_bool(
         request.args.get("dep", default=False)
     )
-    limit = min(int(request.args.get("limit", 5)), int(Config.MAX_SEARCH_LIMIT))
+    # Ensure limit is not negative and within max limits
+    abs_limit = abs(int(request.args.get("limit", 5)))
+    limit = min(abs_limit, int(Config.MAX_SEARCH_LIMIT))
 
     try:
         # Check if the graph is available

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -2,7 +2,7 @@
 import sys
 from rdflib import Graph
 from app import create_app
-from app.config import TestConfig, DeploymentConfig
+from app.config import DeploymentConfig
 from app.models import load_latest_db
 
 # Deployment Configuration

--- a/src/server/tests/functional/test_search_routes.py
+++ b/src/server/tests/functional/test_search_routes.py
@@ -1,0 +1,62 @@
+def test_search_by_id(test_client, sample_graph):
+    """
+    Test the '/search/id' route to search for a node by its URI.
+    """
+    node_uri = "http://data.15926.org/dm/Thing"
+    response = test_client.get(f"/search/id/{node_uri}?limit=5&dep=False")
+    json_data = response.get_json()
+
+    # Assert the response is valid and the node exists
+    assert response.status_code == 200
+    assert json_data["id"] == node_uri
+    assert len(json_data["results"]) > 0  # Ensure results are returned
+
+    # Check that the node exists in the results
+    result_ids = [result["id"] for result in json_data["results"]]
+    assert node_uri in result_ids
+
+
+def test_search_by_id_no_results(test_client):
+    """
+    Test the '/search/id' route when the search yields no results.
+    """
+    invalid_node_uri = "http://data.15926.org/dm/NonExistentNode"
+    response = test_client.get(f"/search/id/{invalid_node_uri}?limit=5&dep=False")
+    json_data = response.get_json()
+
+    # Assert that no results are returned
+    assert response.status_code == 200
+    assert json_data["id"] == invalid_node_uri
+    assert len(json_data["results"]) == 0  # Ensure no results are returned
+
+
+def test_search_by_label(test_client, sample_graph):
+    """
+    Test the '/search/label' route to search for a node by its label.
+    """
+    node_label = "Thing"
+    response = test_client.get(f"/search/label/{node_label}?limit=5&dep=False")
+    json_data = response.get_json()
+
+    # Assert the response is valid and the node with the label exists
+    assert response.status_code == 200
+    assert json_data["label"] == node_label
+    assert len(json_data["results"]) > 0  # Ensure results are returned
+
+    # Check that the node with the label exists in the results
+    result_labels = [result["label"] for result in json_data["results"]]
+    assert node_label in result_labels
+
+
+def test_search_by_label_no_results(test_client):
+    """
+    Test the '/search/label' route when the search yields no results.
+    """
+    invalid_label = "NonExistentLabel"
+    response = test_client.get(f"/search/label/{invalid_label}?limit=5&dep=False")
+    json_data = response.get_json()
+
+    # Assert that no results are returned
+    assert response.status_code == 200
+    assert json_data["label"] == invalid_label
+    assert len(json_data["results"]) == 0  # Ensure no results are returned

--- a/src/server/tests/functional/test_search_routes.py
+++ b/src/server/tests/functional/test_search_routes.py
@@ -8,7 +8,7 @@ def test_search_by_id(test_client, sample_graph):
 
     # Assert the response is valid and the node exists
     assert response.status_code == 200
-    assert json_data["id"] == node_uri
+    assert json_data["search_key"] == node_uri
     assert len(json_data["results"]) > 0  # Ensure results are returned
 
     # Check that the node exists in the results
@@ -26,7 +26,7 @@ def test_search_by_id_no_results(test_client):
 
     # Assert that no results are returned
     assert response.status_code == 200
-    assert json_data["id"] == invalid_node_uri
+    assert json_data["search_key"] == invalid_node_uri
     assert len(json_data["results"]) == 0  # Ensure no results are returned
 
 
@@ -40,7 +40,7 @@ def test_search_by_label(test_client, sample_graph):
 
     # Assert the response is valid and the node with the label exists
     assert response.status_code == 200
-    assert json_data["label"] == node_label
+    assert json_data["search_key"] == node_label
     assert len(json_data["results"]) > 0  # Ensure results are returned
 
     # Check that the node with the label exists in the results
@@ -58,5 +58,5 @@ def test_search_by_label_no_results(test_client):
 
     # Assert that no results are returned
     assert response.status_code == 200
-    assert json_data["label"] == invalid_label
+    assert json_data["search_key"] == invalid_label
     assert len(json_data["results"]) == 0  # Ensure no results are returned


### PR DESCRIPTION
## Description
The API endpoint used for searching has been added, allowing users to search using IDs/URIs on `/search/id/(id)` or their label on `/search/label/(label)`. These routes also support attributes of `dep=True/False` to restrict deprecated items in the search results and `limit=(number >= 0)` to limit the return results. A maximum cap on the limit has been adding using the configuration class, with a default upper limit of `25` and a base default of `5` if limit is not given.

![image](https://github.com/user-attachments/assets/51719df9-b244-4334-abae-268e817b4350)

Results return with an item's deprecation status, id and label for each display.

#### **NOTE: When including spaces in the label search, they must be encoded with `%20`**

## Completed To-do List
* [x] Simple string search for uri or label to serve (id, label)
* [x] Search for either field using url parameters, filtering by deprecated if parameter given

## Misc
Closes #64