### PR TITLE
86 relavent results in search

### DIFF
--- a/src/client/src/components/GraphSearchSidepane.vue
+++ b/src/client/src/components/GraphSearchSidepane.vue
@@ -36,7 +36,7 @@ function toggleLeftNav(): void {
 
 // Function to debounce the search query -- ONLY QUERY AFTER USER STOPS TYPING
 let debounceTimeout: number
-function debounceSearch(fn: () => void, delay: number = 350) {
+function debounceSearch(fn: () => void, delay: number = 450) {
   clearTimeout(debounceTimeout)
   debounceTimeout = setTimeout(fn, delay)
 }
@@ -59,7 +59,7 @@ async function search(query: string): Promise<void> {
   errorMessage.value = ''
   try {
     const endpoint = searchOption.value === 'id' ? '/search/id/' : '/search/label/'
-    const response = await fetch(`${API_URL}${endpoint}${encodeURIComponent(query)}?limit=20`)
+    const response = await fetch(`${API_URL}${endpoint}${encodeURIComponent(query)}?limit=25`)
     const data = await response.json()
 
     if (data.results) {

--- a/src/server/app/config.py
+++ b/src/server/app/config.py
@@ -17,7 +17,7 @@ class Config:
     DB_STORAGE_DIR = os.path.join(basedir, "../db/storage")
 
     # Maximum possible number of items returned by the search api end points
-    MAX_SEARCH_LIMIT = 25
+    MAX_SEARCH_LIMIT = 50
 
 
 class DeploymentConfig(Config):

--- a/src/server/app/routes.py
+++ b/src/server/app/routes.py
@@ -191,6 +191,7 @@ def search(field, search_key):
     Query Parameters:
         dep (bool): Whether to include deprecated nodes. Default is False.
         limit (int): Maximum number of results to return. Default is 5, max is 25.
+        similarity (int): Minimum similarity score of results to return. Default is 75(%)
 
     Returns:
         JSON: The search results by either node ID (URI) or label.
@@ -207,6 +208,8 @@ def search(field, search_key):
     abs_limit = abs(int(request.args.get("limit", 5)))
     limit = min(abs_limit, int(Config.MAX_SEARCH_LIMIT))
 
+    similarity = abs(int(request.args.get("similarity", 75)))
+
     try:
         # Check if the graph is available
         if not hasattr(current_app, "graph"):
@@ -216,11 +219,12 @@ def search(field, search_key):
             return jsonify({"error": "Invalid field. Use 'id' or 'label'."}), 400
 
         results = controllers.search(
-            search_key=search_key,
+            search_key=str(search_key),
             field=field,
             graph=current_app.graph,
             dep=include_deprecation,
             limit=limit,
+            min_similarity=similarity,
         )
 
     except AttributeError as e:

--- a/src/server/requirements.txt
+++ b/src/server/requirements.txt
@@ -6,6 +6,7 @@ click==8.1.7
 exceptiongroup==1.2.2
 Flask==3.0.3
 Flask-Cors==5.0.0
+greenlet==3.0.3
 idna==3.10
 iniconfig==2.0.0
 isodate==0.6.1
@@ -26,6 +27,7 @@ pytest==8.3.2
 pytest-flask==1.3.0
 python-dotenv==1.0.1
 PyYAML==6.0.2
+RapidFuzz==3.10.0
 rdflib==7.0.0
 requests==2.32.3
 rich==13.8.1

--- a/src/server/tests/functional/test_search_routes.py
+++ b/src/server/tests/functional/test_search_routes.py
@@ -1,4 +1,4 @@
-def test_search_by_id(test_client, sample_graph):
+def test_search_by_id(test_client):
     """
     Test the '/search/id' route to search for a node by its URI.
     """
@@ -19,9 +19,12 @@ def test_search_by_id(test_client, sample_graph):
 def test_search_by_id_no_results(test_client):
     """
     Test the '/search/id' route when the search yields no results.
+    Assuming a required >99% score similarity.
     """
     invalid_node_uri = "http://data.15926.org/dm/NonExistentNode"
-    response = test_client.get(f"/search/id/{invalid_node_uri}?limit=5&dep=False")
+    response = test_client.get(
+        f"/search/id/{invalid_node_uri}?limit=5&dep=False&similarity=99"
+    )
     json_data = response.get_json()
 
     # Assert that no results are returned
@@ -30,7 +33,7 @@ def test_search_by_id_no_results(test_client):
     assert len(json_data["results"]) == 0  # Ensure no results are returned
 
 
-def test_search_by_label(test_client, sample_graph):
+def test_search_by_label(test_client):
     """
     Test the '/search/label' route to search for a node by its label.
     """


### PR DESCRIPTION
## Description

Search results on the API route are now ranked based on their similarity to the search key. An added flag has been introduced to allow users to modify the minimum similarity score, which is defaulted to `?similarity=75` to return results that have similarity of 75% or greater. To accommodate these performance impacts by ranking the results, the search field de-bouncing has been increased to 450ms, which is still within unnoticeable limits. Additionally, the default results limit on the client side has been increased from 20 to 25 for more results.
The search is still **case insensitive**.

Thing now appears at the top:
![image](https://github.com/user-attachments/assets/13172b8d-0ab2-4d96-ac3d-98cbd8c23d04)

After some quick tests i have noticed that searching for specific ID's will require significantly more numbers than it used to, as it doesnt return all the results with that number in it but instead by string matching with a score. However, this should be a non-issue as when searching for a specific id using numbers, the user should have the entire id anyways. 
**THIS HAS BEEN RESOLVED BY INTRODUCING CUSTOM RANKER FUNCTION**

## To-dos
- [x] Add relavence ranking to search results.
- [x] Update search field de-bouncing to improve performance impact.

## Misc
Closes #86 