### PR TITLE
90 node collapses to middle to nowhere

### DIFF
--- a/src/client/src/assets/childrenGraphFunctions.ts
+++ b/src/client/src/assets/childrenGraphFunctions.ts
@@ -253,31 +253,6 @@ async function toggleChildrenCollapse(
   }
   // Call the update function to re-render the graph
   updateChildrenGraph(childrenHierarchyData, root, svg, props, emit)
-
-  // const zoom = d3.zoom().on('zoom', (event) => {
-  //   const transform = event.transform
-  //   const combinedTransform = d3.zoomIdentity.translate((3/7)*(window.innerWidth) + transform.x, (3/7)*(window.innerHeight) +transform.y).scale(transform.k)
-
-  //   svg.attr('transform', combinedTransform)
-
-  // })
-  // // Use D3's transition end event to ensure the graph is fully updated before centering the node
-  // svg.transition().duration(750).on('end', () => {
-  //   // Get the dimensions of the SVG element
-  //   const svgElement = svg.node() as SVGSVGElement
-  //   const svgWidth = svgElement.clientWidth
-  //   const svgHeight = svgElement.clientHeight
-
-  //   // Calculate the center of the SVG element
-  //   const centerX = svgWidth / 2
-  //   const centerY = svgHeight / 2
-
-  //   // Calculate the translation to center the node
-  //   const transform = d3.zoomIdentity.translate(-node.y, -node.x).scale(1)
-
-  //   // Apply the transformation to center the node
-  //   svg.transition().duration(750).call(zoom.transform, transform)
-  // })
 }
 
 /**

--- a/src/client/src/assets/childrenGraphFunctions.ts
+++ b/src/client/src/assets/childrenGraphFunctions.ts
@@ -127,7 +127,7 @@ function renderChildrenNodes(
       i === 0 ? 'default' : d.data.has_children ? 'pointer' : 'default'
     )
     .attr('stroke', '#444')
-    // for root node, set stroke width to 3, otherwise 2 if the node has children
+    // set the stroke width based on the node being the root or having children
     .attr('stroke-width', (d: any) =>
       d.data.id === childrenHierarchyData.id || d.data.has_children ? 2 : 0
     )
@@ -385,7 +385,7 @@ function customDiagonal(d: any, offset = 13) {
   // Check if the link is vertical or near-vertical
   if (Math.abs(sourceX - targetX) < 1) {
     // For vertical links, adjust the end point slightly to make arrow visible
-    const arrowAdjustment = isForward ? -offset : offset
+    const arrowAdjustment = targetY > sourceY ? -offset : offset
     return `
       M ${sourceX},${sourceY}
       L ${targetX},${targetY + arrowAdjustment}

--- a/src/client/src/assets/childrenGraphFunctions.ts
+++ b/src/client/src/assets/childrenGraphFunctions.ts
@@ -2,10 +2,8 @@ import * as d3 from 'd3'
 
 import { fetchChildren } from '@/assets/apiFunctions'
 
-// node dimensions + spacing
+// node dimensions, spacing moved to props
 const nodeRadius: number = 7
-const nodeDistanceX: number = 30
-const nodeDistanceY: number = 370
 
 // node visuals
 const nodeDeprecatedColor: string = '#FC1455'
@@ -31,7 +29,7 @@ function drawChildrenGraph(data: any, root: any, svg: any, props: any, emit: any
   root = d3.hierarchy(data)
 
   // Create a tree layout
-  const tree = d3.tree().nodeSize([nodeDistanceX, nodeDistanceY])
+  const tree = d3.tree().nodeSize([props.nodeDistanceX, props.nodeDistanceY])
   // Compute the layout - assigns x and y positions to the nodes
   tree(root)
 
@@ -61,7 +59,7 @@ function updateChildrenGraph(data: any, root: any, svg: any, props: any, emit: a
   root = d3.hierarchy(data, (d: any) => (d.expanded ? d.children : null))
 
   // Create a tree layout
-  const tree = d3.tree().nodeSize([nodeDistanceX, nodeDistanceY])
+  const tree = d3.tree().nodeSize([props.nodeDistanceX, props.nodeDistanceY])
   // Compute the layout - assigns x and y positions to the nodes
   tree(root)
 
@@ -255,6 +253,31 @@ async function toggleChildrenCollapse(
   }
   // Call the update function to re-render the graph
   updateChildrenGraph(childrenHierarchyData, root, svg, props, emit)
+
+  // const zoom = d3.zoom().on('zoom', (event) => {
+  //   const transform = event.transform
+  //   const combinedTransform = d3.zoomIdentity.translate((3/7)*(window.innerWidth) + transform.x, (3/7)*(window.innerHeight) +transform.y).scale(transform.k)
+
+  //   svg.attr('transform', combinedTransform)
+
+  // })
+  // // Use D3's transition end event to ensure the graph is fully updated before centering the node
+  // svg.transition().duration(750).on('end', () => {
+  //   // Get the dimensions of the SVG element
+  //   const svgElement = svg.node() as SVGSVGElement
+  //   const svgWidth = svgElement.clientWidth
+  //   const svgHeight = svgElement.clientHeight
+
+  //   // Calculate the center of the SVG element
+  //   const centerX = svgWidth / 2
+  //   const centerY = svgHeight / 2
+
+  //   // Calculate the translation to center the node
+  //   const transform = d3.zoomIdentity.translate(-node.y, -node.x).scale(1)
+
+  //   // Apply the transformation to center the node
+  //   svg.transition().duration(750).call(zoom.transform, transform)
+  // })
 }
 
 /**

--- a/src/client/src/assets/parentsGraphFunctions.ts
+++ b/src/client/src/assets/parentsGraphFunctions.ts
@@ -128,7 +128,7 @@ function renderParentsNodes(
       i === 0 ? 'default' : d.data.has_parents ? 'pointer' : 'default'
     )
     .attr('stroke', '#444')
-    // for root node, set stroke width to 3, otherwise 2 if the node has parents
+    // set the stroke width based on the node being root or having parents
     .attr('stroke-width', (d: any) =>
       d.data.id === parentHierarchyData.id || d.data.has_parents ? 2 : 0
     )
@@ -383,7 +383,7 @@ function customDiagonal(d: any, offset = 13) {
   // Check if the link is vertical or near-vertical
   if (Math.abs(sourceX - targetX) < 1) {
     // For vertical links, adjust the end point slightly to make arrow visible
-    const arrowAdjustment = isForward ? -offset : offset
+    const arrowAdjustment = targetY > sourceY ? -offset : offset
     return `
       M ${sourceX},${sourceY}
       L ${targetX},${targetY + arrowAdjustment}

--- a/src/client/src/assets/parentsGraphFunctions.ts
+++ b/src/client/src/assets/parentsGraphFunctions.ts
@@ -2,10 +2,8 @@ import * as d3 from 'd3'
 
 import { fetchParents } from '@/assets/apiFunctions'
 
-// node dimensions + spacing
+// node dimensions, spacing moved to props
 const nodeRadius: number = 7
-const nodeDistanceX: number = 30
-const nodeDistanceY: number = 370
 
 // node visuals
 const nodeDeprecatedColor: string = '#FC1455'
@@ -32,7 +30,7 @@ function drawParentsGraph(data: any, root: any, svg: any, props: any, emit: any)
   root = d3.hierarchy(data)
 
   // Create a tree layout
-  const tree = d3.tree().nodeSize([nodeDistanceX, nodeDistanceY])
+  const tree = d3.tree().nodeSize([props.nodeDistanceX, props.nodeDistanceY])
   // Generate the tree layout - assigns x and y positions to all nodes
   tree(root)
 
@@ -62,7 +60,7 @@ function updateParentsGraph(data: any, root: any, svg: any, props: any, emit: an
   root = d3.hierarchy(data, (d: any) => (d.expanded ? d.parents : null))
 
   // Create a tree layout
-  const tree = d3.tree().nodeSize([nodeDistanceX, nodeDistanceY])
+  const tree = d3.tree().nodeSize([props.nodeDistanceX, props.nodeDistanceY])
   // Generate the tree layout - assigns x and y positions to all nodes
   tree(root)
 

--- a/src/client/src/components/GraphExport.vue
+++ b/src/client/src/components/GraphExport.vue
@@ -334,3 +334,18 @@ const closePreview = () => {
   isPreviewVisible.value = false
 }
 </script>
+
+<script lang="ts">
+/**
+ * GraphExport component to export the graph as an image.
+ * This component provides a button to capture the screen and export the graph as an image.
+ * The user can select the file type (PNG, JPEG, or SVG) for the export.
+ * The component also displays a preview of the exported image before saving.
+ *
+ * @example
+ * <GraphExport :svgRef="svgRef" />
+ */
+export default {
+  name: 'GraphExport'
+}
+</script>

--- a/src/client/src/components/GraphVisualisation.vue
+++ b/src/client/src/components/GraphVisualisation.vue
@@ -27,6 +27,20 @@ const props = defineProps({
   showLabels: {
     type: Boolean,
     default: true
+  },
+  /**
+   * The distance between nodes on the X-axis.
+   */
+  nodeDistanceX: {
+    type: Number,
+    default: 45
+  },
+  /**
+   * The distance between nodes on the Y-axis.
+   */
+  nodeDistanceY: {
+    type: Number,
+    default: 450
   }
 })
 

--- a/src/client/src/components/GraphVisualisation.vue
+++ b/src/client/src/components/GraphVisualisation.vue
@@ -44,14 +44,14 @@ const props = defineProps({
    */
   nodeDistanceX: {
     type: Number,
-    default: 45
+    default: 30
   },
   /**
    * The distance between nodes on the Y-axis.
    */
   nodeDistanceY: {
     type: Number,
-    default: 450
+    default: 600
   }
 })
 

--- a/src/client/src/components/GraphVisualisation.vue
+++ b/src/client/src/components/GraphVisualisation.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useWindowSize } from '@vueuse/core'
 import * as d3 from 'd3'
 import { onMounted, ref, watch } from 'vue'
 
@@ -47,13 +48,12 @@ const props = defineProps({
 // Reference to the SVG element
 const svgRef = ref<SVGSVGElement | null>(null)
 
-// Graph size
-const width: number = window.innerWidth
-const height: number = window.innerHeight
+// Get reactive window size from VueUse
+const { width, height } = useWindowSize()
 
 // Graph layout
-const initialGraphX: number = (width / 7) * 3 // Center the graph horizontally
-const initialGraphY: number = (height / 7) * 3
+let initialGraphX: number = (width.value / 7) * 2.5 // Center the graph horizontally
+let initialGraphY: number = (height.value / 7) * 3
 const zoomScale: [number, number] = [0.25, 5]
 
 // D3 variables
@@ -63,6 +63,21 @@ let parentsRoot: any
 
 // Define the emit function to emit the label-clicked event
 const emit = defineEmits(['label-clicked'])
+
+/**
+ * Watch for changes in window size and update the graph dimensions and transform.
+ */
+watch([width, height], () => {
+  // Update the initial graph layout values
+  initialGraphX = (width.value / 7) * 2.5
+  initialGraphY = (height.value / 7) * 3
+
+  // Update the SVG dimensions
+  d3.select(svgRef.value).attr('width', width.value).attr('height', height.value)
+
+  // Reapply the zoom transform
+  svg.attr('transform', d3.zoomIdentity.translate(initialGraphX, initialGraphY).toString())
+})
 
 // onMounted hook to initialise the graph and render with the initial data - prop `Thing` as initial node before search
 onMounted(() => {
@@ -113,8 +128,8 @@ function initialiseGraph() {
   // Create the SVG element
   svg = d3
     .select(svgRef.value as SVGSVGElement)
-    .attr('width', width)
-    .attr('height', height)
+    .attr('width', width.value)
+    .attr('height', height.value)
     .call(d3.zoom().scaleExtent(zoomScale).on('zoom', zoomed) as any)
     .append('g')
     .attr('transform', d3.zoomIdentity.translate(initialGraphX, initialGraphY).toString())

--- a/src/client/src/views/GraphView.vue
+++ b/src/client/src/views/GraphView.vue
@@ -21,6 +21,10 @@ const selectedNodeId = ref('http://data.15926.org/dm/Thing')
 const isLeftExpanded = ref(false)
 const isRightExpanded = ref(false)
 
+// node spacing
+const nodeDistanceX = ref(45)
+const nodeDistanceY = ref(450)
+
 /**
  * Handles the event when the user toggles the deprecated nodes visibility.
  * @param {boolean} val - The new value of the flag to include deprecated nodes.
@@ -90,12 +94,17 @@ watch(
   () => {
     isLeftExpanded.value = false
     isRightExpanded.value = false
+    nodeDistanceX.value = isSm.value ? 30 : 45
+    nodeDistanceY.value = isSm.value ? 300 : 450
   },
   {
     immediate: true
   }
 )
 
+/**
+ * Toggles the left side panel expanded state.
+ */
 function toggleIsLeftExpanded() {
   if (isSm.value && isRightExpanded.value) {
     isRightExpanded.value = false
@@ -103,6 +112,9 @@ function toggleIsLeftExpanded() {
   isLeftExpanded.value = !isLeftExpanded.value
 }
 
+/**
+ * Toggles the right side panel expanded state.
+ */
 function toggleIsRightExpanded() {
   if (isSm.value && isLeftExpanded.value) {
     isLeftExpanded.value = false
@@ -130,6 +142,8 @@ function toggleIsRightExpanded() {
       :selected-node-id="selectedNodeId"
       @label-clicked="handleLabelClicked"
       :show-labels="showLabels"
+      :node-distance-x="nodeDistanceX"
+      :node-distance-y="nodeDistanceY"
     />
   </div>
 </template>

--- a/src/client/src/views/GraphView.vue
+++ b/src/client/src/views/GraphView.vue
@@ -22,8 +22,8 @@ const isLeftExpanded = ref(false)
 const isRightExpanded = ref(false)
 
 // node spacing
-const nodeDistanceX = ref(45)
-const nodeDistanceY = ref(450)
+const nodeDistanceX = ref(30)
+const nodeDistanceY = ref(600)
 
 /**
  * Handles the event when the user toggles the deprecated nodes visibility.

--- a/src/client/src/views/GraphView.vue
+++ b/src/client/src/views/GraphView.vue
@@ -94,8 +94,6 @@ watch(
   () => {
     isLeftExpanded.value = false
     isRightExpanded.value = false
-    nodeDistanceX.value = isSm.value ? 30 : 45
-    nodeDistanceY.value = isSm.value ? 300 : 450
   },
   {
     immediate: true


### PR DESCRIPTION
### Description
* Some bug fixes on resizing page and extra links rendering fixed.
* Node distance variables converted to props for easier updating.
* Unable to complete node collapsing middle of nowhere without rewriting graph zoom transitions while incorporating initial transform from top left to centre of screen thus issue has been dropped.

### Linked Issues
#90 

